### PR TITLE
feat: use org/repo format in plugin config instead of URL

### DIFF
--- a/static/scripts/rendering/plugin-select.ts
+++ b/static/scripts/rendering/plugin-select.ts
@@ -83,6 +83,7 @@ export function renderPluginSelector(renderer: ManifestRenderer): void {
         selectSelected.textContent = optionText;
         closeAllSelect();
         localStorage.setItem("selectedPluginManifest", JSON.stringify(defaultForInstalled));
+        localStorage.setItem("selectedPluginName", pluginName);
         renderConfigEditor(renderer, defaultForInstalled.manifest, installedPlugin?.uses[0].with);
       });
     }

--- a/static/scripts/rendering/write-add-remove.ts
+++ b/static/scripts/rendering/write-add-remove.ts
@@ -46,20 +46,24 @@ export function writeNewConfig(renderer: ManifestRenderer, option: "add" | "remo
 
   renderer.configParser.loadConfig();
   const normalizedPluginName = normalizePluginName(pluginManifest.manifest.name);
-  const pluginUrl = pluginManifest.homepageUrl;
+  const pluginName = localStorage.getItem("selectedPluginName") || normalizedPluginName;
+  
+  // Use org/repo format instead of full URL
+  // The marketplace org is hardcoded as ubiquity-os-marketplace in the fetcher
+  const pluginOrgRepo = `ubiquity-os-marketplace/${pluginName}`;
 
-  if (!pluginUrl) {
-    toastNotification(`No plugin URL found for ${normalizedPluginName}.`, {
+  if (!pluginOrgRepo) {
+    toastNotification(`No plugin reference found for ${normalizedPluginName}.`, {
       type: "error",
       shouldAutoDismiss: true,
     });
-    throw new Error("No plugin URL found");
+    throw new Error("No plugin reference found");
   }
 
   const plugin: Plugin = {
     uses: [
       {
-        plugin: pluginUrl,
+        plugin: pluginOrgRepo,
         with: newConfig,
       },
     ],


### PR DESCRIPTION
This PR resolves https://github.com/ubiquity-os/ubiquity-os-plugin-installer/issues/39

Changes:
- Store selected plugin name in localStorage when selecting a plugin
- Use 'ubiquity-os-marketplace/{pluginName}' format instead of full worker URL

Instead of saving:
```
plugin: https://ubiquity-os-comment-vector-embeddings-development.ubiquity.workers.dev
```

We now save:
```
plugin: ubiquity-os-marketplace/text-vector-embeddings
```